### PR TITLE
isCurrencySupported helper

### DIFF
--- a/src/wallet_address_validator.js
+++ b/src/wallet_address_validator.js
@@ -11,5 +11,11 @@ module.exports = {
     }
 
     throw new Error('Missing validator for currency: ' + currencyNameOrSymbol)
+  },
+  /** Given a currency name or symbol, returns true if the currency has a supported validator function available */
+  isCurrencySupported: function(currencyNameOrSymbol) {
+      const currency = currencies.getByNameOrSymbol(currencyNameOrSymbol || DEFAULT_CURRENCY_NAME);
+
+      return currency && currency.validator;
   }
 }


### PR DESCRIPTION
Instead of relying on an error being thrown inside the UI, it makes sense to just have an option to check if a specific currency is supported or not. 